### PR TITLE
Correct sampling within convex regions

### DIFF
--- a/normal.h
+++ b/normal.h
@@ -56,9 +56,9 @@ static inline double normal(void) {
             x = _FAST_PRNG_SAMPLE_X(X_j, U_1);
             MT_FLUSH();
             U_diff = RANDOM_INT63() - U_1;
-            if (U_diff > min_iE) break;      
-            if (U_diff < -max_iE) continue;
-            if ( _FAST_PRNG_SAMPLE_Y(j, pow(2, 63) - (U_1 + U_diff)) < exp(-0.5*x*x) ) break;
+            if (U_diff >= 0) break;      
+            if (U_diff >= -max_iE &&
+                _FAST_PRNG_SAMPLE_Y(j, pow(2, 63) - (U_1 + U_diff)) < exp(-0.5*x*x) ) break;
             U_1 = RANDOM_INT63();
             }
     } else if (j == 0) {                /* Tail */


### PR DESCRIPTION
Fixes two bugs.

The condition `U_diff >= min_iE` is incorrect (or sub-optimal). The script `create_layers.py` generates `min_iE` using only values outside the convex region, so it does not apply to convex regions. The logic should compare to zero and is thus a negation of the reflection logic used in concave sampling. If a reflection is not required, then the point is within the lower-left triangle and is implicitly accepted.

The second bug is the use of a continue here: `if (U_diff < -max_iE) continue;`. If this executes the next loop will regenerate a point (x,y) within the rectangle using a new Y but the same X. This results in uneven sampling of the rectangle. Higher x values are more likely to be rejected and by reusing X this results in over-sampling of the region towards the outer edge. This can be seen to effect the top layer of the ziggurat (where the correctly scaled |x| < 0.2917) when constructing an approximate PDF using a histogram of the values from the sampler. The central section of the bell curve within +/-0.25 is flattened.

Combining the condition for a fast rejection with the test against the gaussian PDF ensures that any rejected point is replaced with an entirely new (x,y) point in the next iteration.
